### PR TITLE
the parameter is now optional and the semantics changed to the connection name

### DIFF
--- a/resources/config/dist/parameters.yml
+++ b/resources/config/dist/parameters.yml
@@ -3,7 +3,7 @@ parameters:
         #type: jackrabbit
         #url: http://localhost:8080/server/
         type: doctrinedbal
-        connection: doctrine.dbal.default_connection
+        # connection: default
     phpcr_workspace: default
     phpcr_user: admin
     phpcr_pass: admin


### PR DESCRIPTION
after merging https://github.com/doctrine/DoctrinePHPCRBundle/pull/78 the tests go like
https://travis-ci.org/symfony-cmf/CoreBundle/jobs/9224034
