### PR TITLE
Made config filename configurable

### DIFF
--- a/src/Symfony/Cmf/Component/Testing/Functional/BaseTestCase.php
+++ b/src/Symfony/Cmf/Component/Testing/Functional/BaseTestCase.php
@@ -10,10 +10,11 @@ abstract class BaseTestCase extends WebTestCase
     protected $dbManagers = array();
     protected $container;
 
-    public function getContainer()
+    public function getContainer(array $options = array())
     {
-        if (null === $this->container) {
-            $client = $this->createClient();
+        // second condition: when options changed, recache the new container
+        if (null === $this->container || 0 < count($options)) {
+            $client = $this->createClient($options);
             $this->container = $client->getContainer();
         }
 
@@ -48,5 +49,21 @@ abstract class BaseTestCase extends WebTestCase
         $this->dbManagers[$type] = $dbManager;
 
         return $this->getDbManager($type);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected static function createKernel(array $options = array())
+    {
+        if (null === static::$class) {
+            static::$class = static::getKernelClass();
+        }
+
+        return new static::$class(
+            isset($options['environment']) ? $options['environment'] : 'test',
+            isset($options['debug']) ? $options['debug'] : true,
+            isset($options['config_filename']) ? $options['config_filename'] : null
+        );
     }
 }

--- a/src/Symfony/Cmf/Component/Testing/HttpKernel/TestKernel.php
+++ b/src/Symfony/Cmf/Component/Testing/HttpKernel/TestKernel.php
@@ -15,8 +15,21 @@ use Symfony\Component\HttpKernel\Bundle\BundleInterface;
  */
 abstract class TestKernel extends Kernel
 {
+    protected $configFilename;
     protected $bundleSets = array();
     protected $requiredBundles = array();
+
+    /**
+     * @param string  $environment
+     * @param boolean $debug
+     * @param string  $configFilename Optional
+     */
+    public function __construct($environment, $debug, $configFilename = null)
+    {
+        $this->configFilename = $configFilename;
+
+        parent::__construct($environement, $debug);
+    }
 
     /**
      * Register commonly needed bundle sets and then


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | tbd |

A use case: In routing bundle, we need `cmf_routing.persistence.phpcr.enabled = true` for PHPCR tests and `cmf_routing.persistence.orm.enabled true` for ORM tests. You can't enable both at the same time
