### PR TITLE
[2.0] Move doctrine include to phpcr_odm

### DIFF
--- a/resources/config/default.php
+++ b/resources/config/default.php
@@ -15,5 +15,5 @@ $loader->import('dist/framework.yml');
 if (class_exists('Symfony\Bundle\MonologBundle\MonologBundle')) {
     $loader->import('dist/monolog.yml');
 }
-$loader->import('dist/doctrine.yml');
+
 $loader->import('dist/security.yml');

--- a/resources/config/phpcr_odm.php
+++ b/resources/config/phpcr_odm.php
@@ -1,3 +1,4 @@
 <?php
 
+$loader->import(CMF_TEST_CONFIG_DIR.'/dist/doctrine.yml');
 $loader->import(CMF_TEST_CONFIG_DIR.'/dist/phpcrodm.php');

--- a/resources/web/bundles/cmftesting
+++ b/resources/web/bundles/cmftesting
@@ -1,0 +1,1 @@
+/home/daniel/www/TestingBundle/Resources/public

--- a/resources/web/bundles/framework
+++ b/resources/web/bundles/framework
@@ -1,0 +1,1 @@
+/home/daniel/www/TestingBundle/vendor/symfony/symfony/src/Symfony/Bundle/FrameworkBundle/Resources/public


### PR DESCRIPTION
- Removes doctrine bundle dependency - enables use of testing component when Doctrine is not enabled.

/cc @WouterJ 
