### PR TITLE
Update bootstrap.php to launch tests in isolation

### DIFF
--- a/bootstrap/bootstrap.php
+++ b/bootstrap/bootstrap.php
@@ -29,5 +29,9 @@ AnnotationRegistry::registerLoader(function($class) use ($loader) {
 
 AnnotationRegistry::registerFile($vendorDir.'/doctrine/phpcr-odm/lib/Doctrine/ODM/PHPCR/Mapping/Annotations/DoctrineAnnotations.php');
 
-define('CMF_TEST_ROOT_DIR', realpath(__DIR__.'/..'));
-define('CMF_TEST_CONFIG_DIR', CMF_TEST_ROOT_DIR.'/resources/config');
+if (!defined('CMF_TEST_ROOT_DIR')) {
+    define('CMF_TEST_ROOT_DIR', realpath(__DIR__.'/..'));
+}
+if (!defined('CMF_TEST_CONFIG_DIR')) {
+    define('CMF_TEST_CONFIG_DIR', CMF_TEST_ROOT_DIR.'/resources/config');
+}


### PR DESCRIPTION
Hello,
When running tests with processIsolation="true" on phpunit.xml, the bootstrap file is executed for each file. So to run these tests, there is an error: PHPUnit_Framework_Exception : Notice: Constant CMF_TEST_ROOT_DIR already defined in vendor\symfony-cmf\testing\bootstrap\bootstrap.php on line 32

This update resolve the error.

Regards,
