### PR TITLE
Deprecate Content fixture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 Changelog
 =========
 
-* **2013-12-27**: Added XmlSchemaTestCase to test XML schema's
-* **2013-11-17**: Added DatabaseTestListener to support database testing
+* **2013-04-02**: [DEPRECATE] Deprecated `Content` document, it will be
+  removed in 2.0
+* **2013-12-27**: Added `XmlSchemaTestCase` to test XML schema's
+* **2013-11-17**: Added `DatabaseTestListener` to support database testing

--- a/src/Symfony/Cmf/Component/Testing/Document/Content.php
+++ b/src/Symfony/Cmf/Component/Testing/Document/Content.php
@@ -20,6 +20,9 @@ use Symfony\Cmf\Bundle\CoreBundle\Model\ChildInterface;
  *
  * Very simple, referenceable document.
  *
+ * @deprecated This Document is deprecated as of 1.1 and will be removed in 
+ * 2.0. Move the fixture to your own bundle instead.
+ *
  * @PHPCRODM\Document(referenceable=true)
  */
 class Content implements ChildInterface


### PR DESCRIPTION
It does not make sense to have fixtures in this component. A small
change in this class can break it for other bundles using this
component. Each bundle should have their own fixtures, or there should
be some sort of CmfTestingExtension with these common fixtures.

I've chosen to deprecate it and remove it when refactoring, so we have
some time to update all CMF bundles using this document.

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | yes |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |
