### PR TITLE
Deprecated DataFixture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 Changelog
 =========
 
-* **2013-04-02**: [DEPRECATE] Deprecated `Content` document, it will be
-  removed in 2.0
+* **2013-04-07**: [DEPRECATE] Deprecated `LoadBaseData` DataFixture, it will be removed in 2.0
+* **2013-04-02**: [DEPRECATE] Deprecated `Content` document, it will be removed in 2.0
 * **2013-12-27**: Added `XmlSchemaTestCase` to test XML schema's
 * **2013-11-17**: Added `DatabaseTestListener` to support database testing

--- a/src/Symfony/Cmf/Component/Testing/DataFixtures/PHPCR/LoadBaseData.php
+++ b/src/Symfony/Cmf/Component/Testing/DataFixtures/PHPCR/LoadBaseData.php
@@ -16,6 +16,9 @@ use Doctrine\Common\DataFixtures\FixtureInterface;
 use Doctrine\Common\Persistence\ObjectManager;
 use Doctrine\ODM\PHPCR\Document\Generic;
 
+/**
+ * @deprecated Deprecated as of Testing 1.1, will be removed in 2.0
+ */
 class LoadBaseData implements FixtureInterface
 {
     public function load(ObjectManager $manager)


### PR DESCRIPTION
For the same reason as why I proposed to deprecate the Content document.
A library should do this themselves, there is no need to have a data
fixture to add a generic /test node.
