### PR TITLE
add missing admin class for orm environment

### DIFF
--- a/src/Symfony/Cmf/Component/Testing/HttpKernel/TestKernel.php
+++ b/src/Symfony/Cmf/Component/Testing/HttpKernel/TestKernel.php
@@ -70,6 +70,7 @@ abstract class TestKernel extends Kernel
             'Sonata\jQueryBundle\SonatajQueryBundle',
             'Knp\Bundle\MenuBundle\KnpMenuBundle',
             'FOS\JsRoutingBundle\FOSJsRoutingBundle',
+            'Sonata\DoctrineORMAdminBundle\SonataDoctrineORMAdminBundle',
         ));
 
         $this->registerBundleSet('sonata_admin_phpcr', array(


### PR DESCRIPTION
I just realized that i missed one dependency for the `sonata_admin_orm` bundle set. 
