### PR TITLE
avoid double bundle registration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ before_script:
   - composer self-update
   - composer require symfony/symfony:${SYMFONY_VERSION} --prefer-source
 
-script: phpunit --coverage-text
+script: vendor/bin/phpunit -c phpunit.xml.dist --coverage-text
 
 notifications:
   irc: "irc.freenode.org#symfony-cmf"

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,8 @@
         "doctrine/phpcr-bundle": "1.*",
         "doctrine/data-fixtures": "1.0.*",
         "jackalope/jackalope": "1.*",
-        "jackalope/jackalope-doctrine-dbal": "1.*"
+        "jackalope/jackalope-doctrine-dbal": "1.*",
+        "phpunit/phpunit": "3.7.*"
     },
     "autoload": {
         "psr-0": { "Symfony\\Cmf\\Component\\Testing": "src/" }

--- a/src/Symfony/Cmf/Component/Testing/HttpKernel/TestKernel.php
+++ b/src/Symfony/Cmf/Component/Testing/HttpKernel/TestKernel.php
@@ -70,6 +70,7 @@ abstract class TestKernel extends Kernel
             'Sonata\jQueryBundle\SonatajQueryBundle',
             'Knp\Bundle\MenuBundle\KnpMenuBundle',
             'FOS\JsRoutingBundle\FOSJsRoutingBundle',
+            'Sonata\DoctrineORMAdminBundle\SonataDoctrineORMAdminBundle',
         ));
 
         $this->registerBundleSet('sonata_admin_phpcr', array(
@@ -144,7 +145,7 @@ abstract class TestKernel extends Kernel
                 ));
             }
 
-            $this->requiredBundles[] = new $bundle;
+            $this->requiredBundles[$bundle] = new $bundle;
         }
     }
 

--- a/tests/HttpKernel/TestKernelTest.php
+++ b/tests/HttpKernel/TestKernelTest.php
@@ -43,6 +43,7 @@ class TestKernelTest extends \PHPUnit_Framework_TestCase
         return array(
             array(array('default', 'phpcr_odm'), 6),
             array(array('default', 'doctrine_orm'), 5),
+            array(array('default', 'doctrine_orm', 'phpcr_odm'), 6),
         );
     }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | i hope so |
| Fixed tickets | https://github.com/symfony-cmf/Testing/issues/51 |
| License | MIT |
| Doc PR | - |

As described in the issue, i got an exception when trying to use both doctrine bundles in one test. Cause the bundle sets do have common bundles to register. So we need to make the list of required bundles unique. But as there is no real point to have a simple array with some bundle names (bundles are instantiated directly after setting them and stored in the '$requiredBundles'  property of the kernel), i needed to take an other way: i filter the list of required bundles and skip an existing one.
I do not really know if the test pass, got some strange output locally.
