### PR TITLE
move the PHPUnit dependency into the require-dev section to not affect projects that depend on symfony-cmf/Testing

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,9 @@
         "doctrine/phpcr-bundle": "1.*",
         "doctrine/data-fixtures": "1.0.*",
         "jackalope/jackalope": "1.*",
-        "jackalope/jackalope-doctrine-dbal": "1.*",
+        "jackalope/jackalope-doctrine-dbal": "1.*"
+    },
+    "require-dev": {
         "phpunit/phpunit": "3.7.*"
     },
     "autoload": {


### PR DESCRIPTION
see also symfony-cmf/CoreBundle#145
