### PR TITLE
Do not override error reporting configuration

### DIFF
--- a/resources/web/app_test.php
+++ b/resources/web/app_test.php
@@ -2,9 +2,6 @@
 
 use Symfony\Component\HttpFoundation\Request;
 
-ini_set('display_errors', 'On');
-error_reporting(E_ALL);
-
 require_once __DIR__.'/../../bootstrap/bootstrap.php';
 
 $request = Request::createFromGlobals();

--- a/src/HttpKernel/TestKernel.php
+++ b/src/HttpKernel/TestKernel.php
@@ -34,7 +34,7 @@ abstract class TestKernel extends Kernel
      * concrete kernel configure itself using the abstracvt
      * configure() command.
      */
-    public function init()
+    public function __construct($env, $debug)
     {
         $this->registerBundleSet('default', array(
             'Symfony\Bundle\FrameworkBundle\FrameworkBundle',
@@ -84,7 +84,7 @@ abstract class TestKernel extends Kernel
             'FOS\JsRoutingBundle\FOSJsRoutingBundle',
         ));
 
-        parent::init();
+        parent::__construct($env, $debug);
         $this->configure();
     }
 

--- a/tests/HttpKernel/TestKernelTest.php
+++ b/tests/HttpKernel/TestKernelTest.php
@@ -21,7 +21,7 @@ class TestKernelTest extends \PHPUnit_Framework_TestCase
     {
         $this->kernel = $this->getMockBuilder(
             'Symfony\Cmf\Component\Testing\HttpKernel\TestKernel'
-        )->disableOriginalConstructor()->getMockForAbstractClass();
+        )->setConstructorArgs(array('test', true))->getMockForAbstractClass();
         $this->mockBundle = $this->getMock(
             'Symfony\Component\HttpKernel\Bundle\BundleInterface'
         );


### PR DESCRIPTION
- Do not change the default error reporting level
- And fix call to deprecated Kernel::init