### PR TITLE
Added force option to init command

### DIFF
--- a/bin/travis/phpcr_odm_doctrine_dbal.sh
+++ b/bin/travis/phpcr_odm_doctrine_dbal.sh
@@ -4,5 +4,5 @@ DIR_NAME=`dirname $0`
 CONSOLE_DIR=$DIR_NAME"/.."
 
 # composer install --dev
-$CONSOLE_DIR"/console" doctrine:phpcr:init:dbal --drop
+$CONSOLE_DIR"/console" doctrine:phpcr:init:dbal --drop --force
 $CONSOLE_DIR"/console" doctrine:phpcr:repository:init


### PR DESCRIPTION
The init command now requires `--force` as of https://github.com/jackalope/jackalope-doctrine-dbal/pull/232