### PR TITLE
Fix FosJsRoutingBundle requirement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,9 +37,10 @@ matrix:
       env: SYMFONY_VERSION=3.0.*
 
 before_install:
-  - composer self-update || true
+  - composer self-update
   
 install:
+  - if [[ "$TRAVIS_PHP_VERSION" != "hhvm" ]]; then echo "memory_limit = -1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini; fi
   - composer require symfony/symfony:${SYMFONY_VERSION} --no-update
   - composer update --prefer-source $COMPOSER_FLAGS
 

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,8 @@
         "doctrine/phpcr-bundle": "~1.1,>=1.1.0-beta2",
         "doctrine/data-fixtures": "1.*,>=1.0.0-alpha3",
         "jackalope/jackalope": "~1.1,>=1.1.5",
-        "jackalope/jackalope-doctrine-dbal": "~1.1,>=1.1.5"
+        "jackalope/jackalope-doctrine-dbal": "~1.1,>=1.1.5",
+        "friendsofsymfony/jsrouting-bundle": "~1.1"
     },
     "autoload": {
         "psr-4": {

--- a/src/HttpKernel/TestKernel.php
+++ b/src/HttpKernel/TestKernel.php
@@ -57,14 +57,11 @@ abstract class TestKernel extends Kernel
             'Sonata\CoreBundle\SonataCoreBundle',
             'Sonata\AdminBundle\SonataAdminBundle',
             'Knp\Bundle\MenuBundle\KnpMenuBundle',
+            'FOS\JsRoutingBundle\FOSJsRoutingBundle',
         );
         
         if (class_exists('Sonata\jQueryBundle\SonatajQueryBundle')) {
             $baseSonataBundles[] = 'Sonata\jQueryBundle\SonatajQueryBundle';
-        }
-        
-        if (class_exists('FOS\JsRoutingBundle\FOSJsRoutingBundle')) {
-            $baseSonataBundles[] = 'FOS\JsRoutingBundle\FOSJsRoutingBundle';
         }
 
         $this->registerBundleSet('sonata_admin', array_merge(array(


### PR DESCRIPTION
The latest TreeBrowserBundle does no longer install fos js routing bundle. Optionally including this bundle (as done in #103) means tests will fail because we load a not exisiting routing resource file (of FosJsRouting). To support all TreeBrowserBundle/SonataDoctrinePhpcrBundle versions, we have to include this bundle in the sonata bundle sets.