### PR TITLE
Remove annotation registry loading

### DIFF
--- a/bootstrap/bootstrap.php
+++ b/bootstrap/bootstrap.php
@@ -11,24 +11,6 @@ if (!$loader = include $vendorDir.'/autoload.php') {
         'php composer.phar install'.$nl);
 }
 
-use Doctrine\Common\Annotations\AnnotationRegistry;
-
-AnnotationRegistry::registerLoader(function($class) use ($loader) {
-    $loader->loadClass($class);
-
-    // this was class_exists($class, false) i.e. do not autoload.
-    // this is required so that custom annotations (e.g. TreeUiBundle
-    // annotations) are autoloaded - but they should be found by the
-    // composer loader above.
-    //
-    // This probably slows things down.
-    //
-    // @todo: Fix me.
-    return class_exists($class);
-});
-
-AnnotationRegistry::registerFile($vendorDir.'/doctrine/phpcr-odm/lib/Doctrine/ODM/PHPCR/Mapping/Annotations/DoctrineAnnotations.php');
-
 if (!defined('CMF_TEST_ROOT_DIR')) {
     define('CMF_TEST_ROOT_DIR', realpath(__DIR__.'/..'));
 }


### PR DESCRIPTION
All annotation loading configuration could be removed, as it's already done by the PHPunit bridge which we rely on now: https://github.com/symfony/phpunit-bridge/blob/2.7/bootstrap.php#L17-19

This also fixes PHP 7 support (as the `String` annotation is lazy loaded after this PR)