### PR TITLE
Let executor purge the database

### DIFF
--- a/src/Functional/DbManager/PHPCR.php
+++ b/src/Functional/DbManager/PHPCR.php
@@ -79,15 +79,13 @@ class PHPCR
      */
     public function loadFixtures(array $classNames, $initialize = false)
     {
-        $this->purgeRepository();
-
         $loader = new ContainerAwareLoader($this->container);;
 
         foreach ($classNames as $className) {
             $this->loadFixtureClass($loader, $className);
         }
 
-        $this->getExecutor($initialize)->execute($loader->getFixtures(), true);
+        $this->getExecutor($initialize)->execute($loader->getFixtures(), false);
     }
 
     /**


### PR DESCRIPTION
Currently, initializers were never run as they aren't run by the executor when append = true. The executor already purges the database, so no need to purge it ourselves.

As everything is purged already, appending doesn't make much sense.

ping @dantleech can you please verify these changes as you know much more about the Doctrine stuff than me.