### PR TITLE
Undeprecate resources

### DIFF
--- a/resources/config/default.php
+++ b/resources/config/default.php
@@ -9,8 +9,6 @@
  * file that was distributed with this source code.
  */
 
-@trigger_error('The resources/config/'.basename(__FILE__).' file is deprecated since version 1.3 and will be removed in 2.0. Include the config file in your own library instead.');
-
 $kernelRootDir = $container->getParameter('kernel.root_dir');
 $bundleName = null;
 

--- a/resources/config/dist/framework.php
+++ b/resources/config/dist/framework.php
@@ -9,8 +9,6 @@
  * file that was distributed with this source code.
  */
 
-@trigger_error('The resources/config/dist/'.basename(__FILE__).' file is deprecated since version 1.3 and will be removed in 2.0. Include the config file in your own library instead.');
-
 $config = array(
     'secret' => 'test',
     'test' => null,

--- a/resources/config/dist/phpcr_odm.php
+++ b/resources/config/dist/phpcr_odm.php
@@ -9,8 +9,6 @@
  * file that was distributed with this source code.
  */
 
-@trigger_error('The resources/config/dist/'.basename(__FILE__).' file is deprecated since version 1.3 and will be removed in 2.0. Include the config file in your own library instead.');
-
 $config = array(
     'session' => array(
         'backend' => '%phpcr_backend%',

--- a/resources/config/doctrine_orm.php
+++ b/resources/config/doctrine_orm.php
@@ -9,6 +9,4 @@
  * file that was distributed with this source code.
  */
 
-@trigger_error('The resources/config/'.basename(__FILE__).' file is deprecated since version 1.3 and will be removed in 2.0. Include the config file in your own library instead.');
-
 $loader->import(CMF_TEST_CONFIG_DIR.'/dist/doctrine_orm.yml');

--- a/resources/config/phpcr_odm.php
+++ b/resources/config/phpcr_odm.php
@@ -9,6 +9,4 @@
  * file that was distributed with this source code.
  */
 
-@trigger_error('The resources/config/'.basename(__FILE__).' file is deprecated since version 1.3 and will be removed in 2.0. Include the config file in your own library instead.');
-
 $loader->import(CMF_TEST_CONFIG_DIR.'/dist/phpcr_odm.php');

--- a/resources/config/sonata_admin.php
+++ b/resources/config/sonata_admin.php
@@ -9,6 +9,4 @@
  * file that was distributed with this source code.
  */
 
-@trigger_error('The resources/config/'.basename(__FILE__).' file is deprecated since version 1.3 and will be removed in 2.0. Include the config file in your own library instead.');
-
 $loader->import(CMF_TEST_CONFIG_DIR.'/dist/sonata_admin.yml');


### PR DESCRIPTION
On second thought, copying all resources to each bundle is not going to be very usefull. Symfony 2.8 comes with a great, flexible alternative to have default config in this bundle while still allowing changing everything in bundles: the `MicroKernel`. This means that for Testing 2.0 (which will be Symfony >2.8), we can switch to that and deprecating them in 1.3 does no longer make sense.

The deprecation notices weren't working at the moment anyway, because they didn't use the `E_USER_DEPRECATED` level.