### PR TITLE
Removed annotation file load from bootstrap

### DIFF
--- a/bootstrap/bootstrap.php
+++ b/bootstrap/bootstrap.php
@@ -27,8 +27,6 @@ AnnotationRegistry::registerLoader(function($class) use ($loader) {
     return class_exists($class);
 });
 
-AnnotationRegistry::registerFile($vendorDir.'/doctrine/phpcr-odm/lib/Doctrine/ODM/PHPCR/Mapping/Annotations/DoctrineAnnotations.php');
-
 if (!defined('CMF_TEST_ROOT_DIR')) {
     define('CMF_TEST_ROOT_DIR', realpath(__DIR__.'/..'));
 }


### PR DESCRIPTION
The ResourceBundle tests are resolving to the 2.0 branch. This branch still loads the annotations manually.

See: https://github.com/doctrine/phpcr-odm/issues/678#issuecomment-168185652


