### PR TITLE
fix yaml syntax

### DIFF
--- a/resources/config/dist/doctrine.yml
+++ b/resources/config/dist/doctrine.yml
@@ -1,5 +1,5 @@
 doctrine:
     dbal:
-        driver:   %database_driver%
-        path:     %database_path%
+        driver:   "%database_driver%"
+        path:     "%database_path%"
         charset:  UTF8

--- a/resources/config/dist/monolog.yml
+++ b/resources/config/dist/monolog.yml
@@ -2,5 +2,5 @@ monolog:
     handlers:
         main:
             type:  stream
-            path:  %kernel.logs_dir%/%kernel.environment%.log
+            path:  "%kernel.logs_dir%/%kernel.environment%.log"
             level: debug


### PR DESCRIPTION
this invalid syntax is currently supported by symfony but since 3.3 triggers warnings.