### PR TITLE
require phpunit bridge that handles phpunit versions that only have namespaced class names

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     ],
     "require": {
         "php": "^7.0",
-        "symfony/phpunit-bridge": "^3.2",
+        "symfony/phpunit-bridge": "^3.3",
         "symfony/monolog-bundle": "^2.1|^3.0",
         "doctrine/common": "^2.4",
         "doctrine/doctrine-bundle": "^1.0|^2.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | for new versions, only relevant from phpunit 6 on.
| Bug fix?      | -
| New feature?  | -
| BC breaks?    | -
| Deprecations? | -
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

discovered in https://github.com/doctrine/DoctrinePHPCRBundle/pull/291