### PR TITLE
DevKit updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ cache:
     - $HOME/.composer/cache/files
 
 env:
-  matrix: SYMFONY_VERSION=^3.4@dev
+  matrix: SYMFONY_VERSION=^4.0@dev
   global:
     - SYMFONY_DEPRECATIONS_HELPER=0
     - SYMFONY_PHPUNIT_DIR=.phpunit SYMFONY_PHPUNIT_REMOVE="symfony/yaml"
@@ -36,18 +36,16 @@ env:
 matrix:
   include:
     - php: 7.1
-      env: DEPS=dev SYMFONY_VERSION=^4@dev
-    - php: 7.1
-      env: DEPS=dev SYMFONY_VERSION=^3.4@dev
+      env: DEPS=dev SYMFONY_VERSION=^4.0@dev
     - php: 7.1
       env: COMPOSER_FLAGS="--prefer-lowest" SYMFONY_VERSION=2.8.* SYMFONY_DEPRECATIONS_HELPER=weak
     - php: 7.1
       env: SYMFONY_VERSION=3.3.*
+    - php: 7.1
+      env: SYMFONY_VERSION=^3.4@dev
 
   fast_finish: true
   allow_failures:
-    - php: 7.1
-      env: DEPS=dev SYMFONY_VERSION=^4@dev
 
 
 before_install:

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ the context of the CMF.
 ## Requirements
 
 * PHP 7.1
-* Symfony 2.8 / 3.3 / ^3.4@dev
+* Symfony 2.8 / 3.3 / ^3.4@dev / ^4.0@dev
 * See also the `require` section of [composer.json](composer.json)
 
 ## Documentation


### PR DESCRIPTION
moves symfony 4.0 to the versions, which are not allowed to fail