### PR TITLE
the repositorymanager is not BC with the PHPCR manager

### DIFF
--- a/src/Functional/BaseTestCase.php
+++ b/src/Functional/BaseTestCase.php
@@ -14,6 +14,7 @@ namespace Symfony\Cmf\Component\Testing\Functional;
 use Doctrine\Bundle\PHPCRBundle\Test\RepositoryManager;
 use Symfony\Bundle\FrameworkBundle\Client;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Cmf\Component\Testing\Functional\DbManager\PhpcrDecorator;
 use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -114,7 +115,7 @@ abstract class BaseTestCase extends WebTestCase
         );
 
         if ('phpcr' === strtolower($type) && class_exists(RepositoryManager::class)) {
-            $className = RepositoryManager::class;
+            $className = PhpcrDecorator::class;
         }
 
         if (!class_exists($className)) {

--- a/src/Functional/DbManager/PhpcrDecorator.php
+++ b/src/Functional/DbManager/PhpcrDecorator.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of the Symfony CMF package.
+ *
+ * (c) 2011-2017 Symfony CMF
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Cmf\Component\Testing\Functional\DbManager;
+
+use Doctrine\Bundle\PHPCRBundle\Test\RepositoryManager;
+use Doctrine\ODM\PHPCR\DocumentManagerInterface;
+
+/**
+ * A decorator around the DoctrinePHPCRBundle RepositoryManager class to
+ * provide BC with the PHPCR manager in this bundle.
+ */
+class PhpcrDecorator extends RepositoryManager
+{
+    public function getOm(string $managerName = null): DocumentManagerInterface
+    {
+        return $this->getDocumentManager($managerName);
+    }
+
+    /**
+     * Create a test node, if the test node already exists, remove it.
+     */
+    public function createTestNode()
+    {
+        $session = $this->getDocumentManager()->getPhpcrSession();
+
+        if ($session->nodeExists('/test')) {
+            $session->getNode('/test')->remove();
+        }
+
+        $session->getRootNode()->addNode('test', 'nt:unstructured');
+
+        $session->save();
+    }
+}


### PR DESCRIPTION
i did not add methods to DoctrinePHPCRBundle for things that are not used in the bundle itself. the createTestNode method is used by cmf bundles, have testing provide a method for this.