### PR TITLE
Do not pass command line as array to Process

### DIFF
--- a/src/Phpunit/DatabaseTestListener.php
+++ b/src/Phpunit/DatabaseTestListener.php
@@ -14,6 +14,7 @@ namespace Symfony\Cmf\Component\Testing\Phpunit;
 use Doctrine\Common\DataFixtures\Purger;
 use Symfony\Component\Process\PhpExecutableFinder;
 use Symfony\Component\Process\Process;
+use Symfony\Component\Process\ProcessUtils;
 
 class DatabaseTestListener implements \PHPUnit_Framework_TestListener
 {
@@ -42,6 +43,10 @@ class DatabaseTestListener implements \PHPUnit_Framework_TestListener
             $callable = $this->processCallable;
 
             return $callable($arguments);
+        }
+
+        if (is_array($arguments) && method_exists(ProcessUtils::class, 'escapeArgument')) {
+            $arguments = implode(' ', array_map([ProcessUtils::class, 'escapeArgument'], $arguments));
         }
 
         return new Process($arguments);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | "master"
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | https://github.com/sonata-project/SonataDoctrinePhpcrAdminBundle/pull/526
| License       | MIT

A first argument of `Symfony\Component\Process\Process` can be an array only since Symfony 3.3

But now it is always passes an array from `Symfony\Cmf\Component\Testing\Phpunit\DatabaseTestListener::getProcess`. With this PR `$arguments` is converted from array to a string via old method, removed in Symfony4.0.

I.e. for Symfony < 4.0, `$arguments` will be converted to a string, for Symfony>=4.0 it won't be changed

Also, right now a travis job https://travis-ci.org/sonata-project/SonataDoctrinePhpcrAdminBundle/jobs/395310744 of https://github.com/sonata-project/SonataDoctrinePhpcrAdminBundle/pull/521 was failed because of it.