### PR TITLE
Read KERNEL_DIR and KERNEL_CLASS from phpunit.xml.dist for bin/console

### DIFF
--- a/bootstrap/kernel_bootstrap.php
+++ b/bootstrap/kernel_bootstrap.php
@@ -34,7 +34,7 @@ if (!count($envDir)) {
 }
 $envClass = $xml->xpath("//php/env[@name='KERNEL_CLASS']");
 
-$kernelClass = null === $envClass ? 'AppKernel' : (string) $envClass[0]['value'];
+$kernelClass = count($envClass) ? (string) $envClass[0]['value'] : 'AppKernel';
 $kernelNs = explode('\\', $kernelClass);
 $kernelFile = $rootDir.'/'.$envDir[0]['value'].'/'.array_pop($kernelNs).'.php';
 

--- a/bootstrap/kernel_bootstrap.php
+++ b/bootstrap/kernel_bootstrap.php
@@ -25,9 +25,18 @@ if (!file_exists($phpUnitFile)) {
 }
 
 $xml = new \SimpleXMLElement(file_get_contents($phpUnitFile));
-$kernelDir = $xml->php[0]->server[0]['value'];
 
-$kernelFile = $rootDir.'/'.$kernelDir.'/AppKernel.php';
+$envDir = $xml->xpath("//php/server[@name='KERNEL_DIR']");
+if (!count($envDir)) {
+    throw new \Exception(
+        'Kernel path must be set via <server name"KERNEL_DIR" value="..."/>'
+    );
+}
+$envClass = $xml->xpath("//php/env[@name='KERNEL_CLASS']");
+
+$kernelClass = null === $envClass ? 'AppKernel' : (string) $envClass[0]['value'];
+$kernelNs = explode('\\', $kernelClass);
+$kernelFile = $rootDir.'/'.$envDir[0]['value'].'/'.array_pop($kernelNs).'.php';
 
 if (!file_exists($kernelFile)) {
     throw new \Exception(sprintf(
@@ -38,4 +47,4 @@ if (!file_exists($kernelFile)) {
 
 require_once $kernelFile;
 
-return new AppKernel($env, true);
+return new $kernelClass($env, true);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | "master"
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 
| License       | MIT
| Doc PR        | reference to the documentation PR, if any

This PR allows to execute `vendor/symfony-cmf/testing/bin/console` without setting environment variables: `KERNEL_DIR` and `KERNEL_CLASS` will be readed from `phpunit.xml.dist` file:

```xml
<?xml version="1.0" encoding="UTF-8"?>
<phpunit>
    <!-- ..... -->
    <php>
        <ini name="precision" value="8"/>
        <server name="KERNEL_DIR" value="tests/Fixtures/App"/>
        <env name="KERNEL_CLASS" value="Sonata\DoctrinePHPCRAdminBundle\Tests\Fixtures\App\Kernel"/>
    </php>
</phpunit>
```

If this PR will be accepted, `Makefile` in https://github.com/sonata-project/SonataDoctrinePhpcrAdminBundle/pull/521 could be left not modified. After this PR we will modify `sonata-project/dev-kit` to execute 2 console commands in `.travis/before_script_test.sh`:

    vendor/symfony-cmf/testing/bin/console doctrine:phpcr:init:dbal --drop --force
    vendor/symfony-cmf/testing/bin/console doctrine:phpcr:repository:init

before running PHPUnit 5.7 as before in `Makefile`

    phpunit -c phpunit.xml.dist --coverage-clover build/logs/clover.xml
