### PR TITLE
Put KERNEL_CLASS to environment if it was not there yet

### DIFF
--- a/bootstrap/kernel_bootstrap.php
+++ b/bootstrap/kernel_bootstrap.php
@@ -29,6 +29,7 @@ $xml = new \SimpleXMLElement(file_get_contents($phpUnitFile));
 $envClass = $xml->xpath("//php/env[@name='KERNEL_CLASS']");
 if (count($envClass)) {
     $kernelClass = (string) $envClass[0]['value'];
+    putenv(sprintf('KERNEL_CLASS=%s', $kernelClass));
 } else {
     $envDir = $xml->xpath("//php/server[@name='KERNEL_DIR']");
     if (!count($envDir)) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | "master"
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

If `KERNEL_CLASS` env variable was not set, and it was read from `phpunit.xml.dist` it must be put to environment, because `phpcr-odm` testing configuration relies on this environment variable

See https://github.com/symfony-cmf/testing/blob/master/resources/config/dist/phpcr_odm.php

```php
if (getenv('KERNEL_CLASS')) {
    $phpcrOdmDocDir = sprintf('%s/Document', $kernelRootDir);
    $phpcrOdmDocPrefix = sprintf('%s\Tests\Fixtures\App\Document', $bundleFQN);
} else {
    $phpcrOdmDocDir = sprintf('%s/../Document', $kernelRootDir);
    $phpcrOdmDocPrefix = sprintf('%s\Tests\Resources\Document', $bundleFQN);
}
```

If `KERNEL_CLASS` environment was not set, `test_additional` odm mappings is not added and tests are not passed with the following error:

    Doctrine\Common\Persistence\Mapping\MappingException: The class 'Sonata\DoctrinePHPCRAdminBundle\Tests\Fixtures\App\Document\Content' was not found in the chain configured namespaces Doctrine\ODM\PHPCR\Document, App\Document
