### PR TITLE
avoid using same kernel for orm and phpcr

### DIFF
--- a/src/Functional/BaseTestCase.php
+++ b/src/Functional/BaseTestCase.php
@@ -85,17 +85,25 @@ abstract class BaseTestCase extends WebTestCase
      */
     public function getKernel()
     {
-        if (null === self::$kernel) {
-            $kernel = parent::bootKernel();
-            if ($kernel instanceof KernelInterface) {
-                self::$kernel = $kernel;
-            }
-        }
-        if (!self::$kernel->getContainer()) {
-            self::$kernel->boot();
+        if (null === static::$kernel) {
+            parent::bootKernel(static::getKernelConfiguration());
         }
 
-        return self::$kernel;
+        if (static::$kernel instanceof  KernelInterface) {
+            $kernelEnvironment = static::$kernel->getEnvironment();
+            $expectedEnvironment = isset($this->getKernelConfiguration()['environment'])
+                ? $this->getKernelConfiguration()['environment']
+                : 'phpcr';
+            if ($kernelEnvironment !== $expectedEnvironment) {
+                parent::bootKernel(static::getKernelConfiguration());
+            }
+        }
+
+        if (!static::$kernel->getContainer()) {
+            static::$kernel->boot();
+        }
+
+        return static::$kernel;
     }
 
     /**

--- a/tests/Fixtures/TestTestCase.php
+++ b/tests/Fixtures/TestTestCase.php
@@ -18,15 +18,15 @@ class TestTestCase extends BaseTestCase
 {
     public function setKernel(KernelInterface $kernel)
     {
-        self::$kernel = $kernel;
+        static::$kernel = $kernel;
     }
 
     protected static function createKernel(array $options = [])
     {
-        if (null === self::$kernel) {
+        if (null === static::$kernel) {
             return parent::createKernel($options);
         }
 
-        return self::$kernel;
+        return static::$kernel;
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | "master" for new features / the branch of the current release for fixes
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | yes/no
| Deprecations? | yes/no
| Fixed tickets | comma-separated list of tickets fixed by the PR, if any
| License       | MIT
| Doc PR        | reference to the documentation PR, if any

This change should avoid sharing a kernel for `phpcr` envirionment on an `orm` environment. I really played around with phpunit properties for backup of static properties and i failed. In general several classes - and even the test-case - is cached and backuped. So the `$kernel` stays alive through different processes. And yea, i even tried to separate it into different processes, but that failed also. So instead of destroying the kernel on tearDown, we simply check if we have the correct one.