### PR TITLE
Avoid name collision with parent method

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -12,4 +12,8 @@
         </testsuite>
     </testsuites>
 
+    <listeners>
+       <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener" />
+    </listeners>
+
 </phpunit>

--- a/src/Functional/BaseTestCase.php
+++ b/src/Functional/BaseTestCase.php
@@ -54,12 +54,26 @@ abstract class BaseTestCase extends WebTestCase
         return [];
     }
 
+    public function __call($name, $arguments)
+    {
+        if ('getClient' === $name) {
+            @trigger_error(sprintf(
+                '"%s::getClient()" is deprecated in favor of getFrameworkBundleClient() since symfony-cmf/testing 2.1 and will no longer be callable in 3.0',
+                __CLASS__
+            ), E_USER_DEPRECATED);
+
+            return $this->getFrameworkBundleClient();
+        }
+
+        return parent::$name(...$arguments);
+    }
+
     /**
      * Gets the Client.
      *
      * @return Client
      */
-    public function getClient()
+    public function getFrameworkBundleClient()
     {
         if (null === $this->client) {
             $this->client = $this->createClient($this->getKernelConfiguration());

--- a/tests/Functional/BaseTestCaseTest.php
+++ b/tests/Functional/BaseTestCaseTest.php
@@ -77,6 +77,20 @@ class BaseTestCaseTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * @group legacy
+     * @expectedDeprecation "Symfony\Cmf\Component\Testing\Functional\BaseTestCase::getClient()" is deprecated in favor of getFrameworkBundleClient() since symfony-cmf/testing 2.1 and will no longer be callable in 3.0
+     */
+    public function testItTriggersADeprecationErrorWhenCallingGetClient()
+    {
+        $this->assertInstanceOf(Client::class, $this->testCase->getClient());
+    }
+
+    public function testItCanProvideAFrameworkBundleClient()
+    {
+        $this->assertInstanceOf(Client::class, $this->testCase->getFrameworkBundleClient());
+    }
+
+    /**
      * @dataProvider provideTestDb
      * @depends testGetContainer
      */


### PR DESCRIPTION
Since symfony/symfony@4f91020 , that ships with 4.3.0, there is a
collision between a private static method in a trait use in an ancestor
class of BaseTestCase and the method in BaseTestCase.
See https://github.com/symfony/symfony/blob/950306adaad8b23725c4efeaf6c570d89e17f164/src/Symfony/Bundle/FrameworkBundle/Test/WebTestAssertionsTrait.php#L189
Closes #192

| Q             | A
| ------------- | ---
| Branch?       | 2.1
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes
| Fixed tickets | #192
| License       | MIT
| Doc PR        | n/a
