### PR TITLE
Require proper monolog-bundle dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "symfony/framework-bundle": "^3.4.22 || ^4.1 || ^5.0",
         "symfony/http-foundation": "^3.4.22 || ^4.1 || ^5.0",
         "symfony/http-kernel": "^3.4.22 || ^4.1 || ^5.0",
-        "symfony/monolog-bundle": "~3.1 || ^5.0",
+        "symfony/monolog-bundle": "^3.5",
         "symfony/process": "^3.4.22 || ^4.1 || ^5.0",
         "symfony/security-bundle": "^3.4.22 || ^4.1 || ^5.0",
         "symfony/twig-bundle": "^3.4.22 || ^4.1 || ^5.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | "master" 
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

There is no `5.x` branch in [monolog-bundle](https://github.com/symfony/monolog-bundle/releases)