### PR TITLE
Remove templating config from default.php

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+3.1.0
+-----
+
+* **2020-02-24**: [BC-BREAK] Remove framework templating configuration from prepended config.
+
 3.0.0
 -----
 

--- a/resources/config/dist/framework.php
+++ b/resources/config/dist/framework.php
@@ -24,9 +24,6 @@ $config = [
         'resource' => '%kernel.root_dir%/config/routing.php',
     ],
     'default_locale' => 'en',
-    'templating' => [
-        'engines' => ['twig'],
-    ],
     'translator' => [
         'fallback' => 'en',
     ],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | -
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

The framework.tempating does not longer exist in symfony 5 so we should remove it from the default.php if somebody want to configure it it should be done in its project.
