### PR TITLE
Remove symfony debug component as requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,8 +11,7 @@
     "require": {
         "php": "^7.1",
         "doctrine/data-fixtures": "^1.2",
-        "symfony/browser-kit": "^3.4.26 || ^4.3.8 || ^5.0",
-        "symfony/debug": "^3.4.22 || ^4.1 || ^5.0"
+        "symfony/browser-kit": "^3.4.26 || ^4.3.8 || ^5.0"
     },
     "require-dev": {
         "doctrine/doctrine-bundle": "^1.8 || ^2.0",

--- a/resources/web/app.php
+++ b/resources/web/app.php
@@ -9,12 +9,17 @@
  * file that was distributed with this source code.
  */
 
-use Symfony\Component\Debug\Debug;
+use Symfony\Component\Debug\Debug as LegacyDebug;
+use Symfony\Component\ErrorHandler\Debug;
 use Symfony\Component\HttpFoundation\Request;
 
 require_once __DIR__.'/../../bootstrap/bootstrap.php';
 
-Debug::enable();
+if (class_exists(Debug::class)) {
+    Debug::enable();
+} elseif (class_exists(LegacyDebug::class)) {
+    LegacyDebug::enable();
+}
 
 $request = Request::createFromGlobals();
 $env = $request->query->get('env', 'phpcr');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | "master" 
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | -
| License       | MIT
| Doc PR        | reference to the documentation PR, if any

Currently it will install symfony/debug this component is deprecated and should be replaced with symfony/error-handler. I did make the only call to this component optional. Based on the install debug or error handler the correct component is called.