### PR TITLE
make compatible with newer doctrine persistence versions

### DIFF
--- a/src/Functional/DbManager/ORM.php
+++ b/src/Functional/DbManager/ORM.php
@@ -16,8 +16,10 @@ use Doctrine\Common\DataFixtures\Executor\ORMExecutor;
 use Doctrine\Common\DataFixtures\Loader;
 use Doctrine\Common\DataFixtures\ProxyReferenceRepository;
 use Doctrine\Common\DataFixtures\Purger\ORMPurger;
-use Doctrine\Common\Persistence\ManagerRegistry;
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Common\Persistence\ManagerRegistry as LegacyManagerRegistry;
+use Doctrine\Common\Persistence\ObjectManager as LegacyObjectManager;
+use Doctrine\Persistence\ManagerRegistry;
+use Doctrine\Persistence\ObjectManager;
 use Symfony\Bridge\Doctrine\DataFixtures\ContainerAwareLoader;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
@@ -45,20 +47,23 @@ class ORM
      */
     protected $om;
 
-    /**
-     * Constructor.
-     */
     public function __construct(ContainerInterface $container)
     {
         $this->container = $container;
     }
 
-    public function getRegistry(): ManagerRegistry
+    /**
+     * @return ManagerRegistry|LegacyManagerRegistry
+     */
+    public function getRegistry()
     {
         return $this->container->get('doctrine');
     }
 
-    public function getOm($managerName = null): ObjectManager
+    /**
+     * @return ObjectManager|LegacyObjectManager
+     */
+    public function getOm($managerName = null)
     {
         if (!$this->om) {
             $this->om = $this->getRegistry()->getManager($managerName);

--- a/src/Functional/DbManager/PHPCR.php
+++ b/src/Functional/DbManager/PHPCR.php
@@ -16,8 +16,9 @@ use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Common\DataFixtures\Loader;
 use Doctrine\Common\DataFixtures\ProxyReferenceRepository;
 use Doctrine\Common\DataFixtures\Purger\PHPCRPurger;
-use Doctrine\Common\Persistence\ManagerRegistry;
+use Doctrine\Common\Persistence\ManagerRegistry as LegacyManagerRegistry;
 use Doctrine\ODM\PHPCR\DocumentManager;
+use Doctrine\Persistence\ManagerRegistry;
 use Symfony\Bridge\Doctrine\DataFixtures\ContainerAwareLoader;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
@@ -40,7 +41,10 @@ class PHPCR
         $this->container = $container;
     }
 
-    public function getRegistry(): ManagerRegistry
+    /**
+     * @return ManagerRegistry|LegacyManagerRegistry
+     */
+    public function getRegistry()
     {
         return $this->container->get('doctrine_phpcr');
     }


### PR DESCRIPTION
we need to remove the typehint, because very old versions of doctrine still have persistence in the commons, and the newest versions no longer have the BC layer.