### PR TITLE
Adjust to Symfony FrameworkBundle changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+4.0.0
+-----
+
+* [BC-BREAK] Made bootstrap utility methods in BaseTestCase static to not conflict with recent versions of Symfony FrameworkBundle.
+
 3.3.0
 -----
 

--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "3.x-dev"
+            "dev-master": "4.x-dev"
         }
     }
 }

--- a/resources/web/router.php
+++ b/resources/web/router.php
@@ -20,6 +20,6 @@ if ($asset !== __DIR__.'/' && file_exists($asset)) {
 
 // otherwise lets run the application
 $_SERVER['DOCUMENT_ROOT'] = __DIR__;
-$_SERVER['SCRIPT_FILENAME'] = __DIR__.DIRECTORY_SEPARATOR.'app_test.php';
+$_SERVER['SCRIPT_FILENAME'] = __DIR__.\DIRECTORY_SEPARATOR.'app_test.php';
 
 require 'app_test.php';

--- a/tests/Fixtures/TestTestCase.php
+++ b/tests/Fixtures/TestTestCase.php
@@ -24,7 +24,7 @@ class TestTestCase extends BaseTestCase
     protected static function createKernel(array $options = []): KernelInterface
     {
         if (null === static::$kernel) {
-            return parent::createKernel($options);
+            static::$kernel = parent::createKernel($options);
         }
 
         return static::$kernel;

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -12,7 +12,7 @@
 $vendorDir = realpath(__DIR__.'/../vendor');
 
 if (!$loader = include $vendorDir.'/autoload.php') {
-    $nl = PHP_SAPI === 'cli' ? PHP_EOL : '<br />';
+    $nl = \PHP_SAPI === 'cli' ? \PHP_EOL : '<br />';
     echo "$nl$nl";
     exit('You must set up the project dependencies.'.$nl.
         'Run the following commands in '.dirname(__DIR__).':'.$nl.$nl.


### PR DESCRIPTION
The FrameworkBundle BaseTestCase introduced `getContainer`, which
collides with the non-static method of the same name provided in this
component.

Make getContainer (and other methods) static to match.

| Q             | A
| ------------- | ---
| Branch?       | "master"
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | yes
| Deprecations? | no
| Fixed tickets | -
| License       | MIT
| Doc PR        | -
