### PR TITLE
Extra config changes needed to ensure compitbility over all symfony versions

### DIFF
--- a/resources/config/default.php
+++ b/resources/config/default.php
@@ -24,13 +24,13 @@ if (preg_match('&/([a-zA-Z]+?)Bundle&', $kernelRootDir, $matches)) {
 }
 
 if ($container->hasParameter('kernel.project_dir')) {
-    $loader->import('dist/parameters_sf5.yml');
+    $loader->import(__DIR__.'/dist/parameters_sf5.yml');
 } else {
-    $loader->import('dist/parameters.yml');
+    $loader->import(__DIR__.'/dist/parameters.yml');
 }
 if (class_exists('Symfony\Bundle\MonologBundle\MonologBundle')) {
-    $loader->import('dist/monolog.yml');
+    $loader->import(__DIR__.'/dist/monolog.yml');
 }
-$loader->import('dist/doctrine.yml');
-$loader->import('dist/framework.php');
-$loader->import('dist/security.php');
+$loader->import(__DIR__.'/dist/doctrine.yml');
+$loader->import(__DIR__.'/dist/framework.php');
+$loader->import(__DIR__.'/dist/security.php');

--- a/resources/config/dist/security.php
+++ b/resources/config/dist/security.php
@@ -45,4 +45,12 @@ if (class_exists(\Symfony\Component\Security\Core\Authentication\Provider\Anonym
     $config = array_merge($config, ['firewall' => ['main' => ['anonymous' => null]]]);
 }
 
+if (interface_exists(\Symfony\Component\PasswordHasher\PasswordHasherInterface::class)) {
+    unset($config['encoders']);
+    $config = array_merge($config, [
+        'enable_authenticator_manager' => true,
+        'password_hashers' => ['Symfony\Component\Security\Core\User\User' => 'plaintext'],
+    ]);
+}
+
 $container->loadFromExtension('security', $config);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | "master" for new features / the branch of the current release for fixes
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

Follow up of #210 and #211. Some extra config changes found while adding symfony 6 compatibility to `symfony-cmf/routing-bundle`

* Use full config path to avoid loading issues with changes currentDir
* Don't use deprecated `encoders` security config when the password hasher component is available
