### PR TITLE
Call AnnotationRegistry registerLoader only when available

### DIFF
--- a/.github/workflows/test-application.yaml
+++ b/.github/workflows/test-application.yaml
@@ -51,6 +51,9 @@ jobs:
 
             - name: Install Symfony Flex
               run: composer global require --no-progress --no-scripts --no-plugins symfony/flex
+              
+            - name: Allow Symfony Flex Plugin
+              run: composer global config --no-plugins allow-plugins.symfony/flex true
 
             - name: Install dependencies with Composer
               uses: ramsey/composer-install@v1

--- a/bootstrap/bootstrap.php
+++ b/bootstrap/bootstrap.php
@@ -23,19 +23,21 @@ if (!$loader = include $vendorDir.'/autoload.php') {
 
 use Doctrine\Common\Annotations\AnnotationRegistry;
 
-AnnotationRegistry::registerLoader(function ($class) use ($loader) {
-    $loader->loadClass($class);
+if (method_exists(AnnotationRegistry::class, 'registerLoader')) {
+    AnnotationRegistry::registerLoader(function ($class) use ($loader) {
+        $loader->loadClass($class);
 
-    // this was class_exists($class, false) i.e. do not autoload.
-    // this is required so that custom annotations (e.g. TreeUiBundle
-    // annotations) are autoloaded - but they should be found by the
-    // composer loader above.
-    //
-    // This probably slows things down.
-    //
-    // @todo: Fix me.
-    return class_exists($class);
-});
+        // this was class_exists($class, false) i.e. do not autoload.
+        // this is required so that custom annotations (e.g. TreeUiBundle
+        // annotations) are autoloaded - but they should be found by the
+        // composer loader above.
+        //
+        // This probably slows things down.
+        //
+        // @todo: Fix me.
+        return class_exists($class);
+    });
+}
 
 if (!defined('CMF_TEST_ROOT_DIR')) {
     define('CMF_TEST_ROOT_DIR', realpath(__DIR__.'/..'));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | "master" for new features / the branch of the current release for fixes
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | comma-separated list of tickets fixed by the PR, if any
| License       | MIT
| Doc PR        | reference to the documentation PR, if any

Did run into an issue with Annotationregistry loader in phpcr migration bundle: https://github.com/dantleech/phpcr-migrations-bundle/actions/runs/4430029921/jobs/7771245561