### PR TITLE
allow data fixtures version 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ Changelog
 5.x
 ===
 
+5.0.4
+-----
+
+* Allow data fixtures version 2, to make this actually installable with Doctrine and Symfony 8.
+
 5.0.3
 -----
 

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     ],
     "require": {
         "php": "^8.1",
-        "doctrine/data-fixtures": "^1.2",
+        "doctrine/data-fixtures": "^1.2 || ^2.0",
         "symfony/browser-kit": "^6.4 || ^7.0 || ^8.0"
     },
     "require-dev": {

--- a/src/Unit/Constraint/SchemaAcceptsXml.php
+++ b/src/Unit/Constraint/SchemaAcceptsXml.php
@@ -57,6 +57,7 @@ class SchemaAcceptsXml extends Constraint
 
     public function toString(): string
     {
+        return 'schema-accepts-xml';
     }
 
     protected function failureDescription($schemaFile): string
@@ -75,7 +76,7 @@ class SchemaAcceptsXml extends Constraint
             $error = trim($error->message).($error->file ? ' in'.$error->file : '').' on line '.$error->line."\n";
 
             // avoid repeating same error
-            if (false === strpos($str, $error)) {
+            if (!str_contains($str, $error)) {
                 $str .= $error;
             }
         }


### PR DESCRIPTION
Otherwise we can't install this together with doctrine and symfony 8.